### PR TITLE
Added support for scales and streams

### DIFF
--- a/config.stream.json
+++ b/config.stream.json
@@ -1,0 +1,21 @@
+{
+	"type" : "stream"
+	, "layout" : {
+
+		"zero" : [ "a" ]
+		, "plus1" : [ "s" ]
+		, "plus2" : [ "d" ]
+		, "plus3" : [ "f" ]
+		, "plus4" : [ "g" ]
+		, "plus5" : [ "h" ]
+		, "plus6" : [ "j" ]
+		, "plus7" : [ "k" ]
+		, "minus1" : [ "x" ]
+		, "minus2" : [ "c" ]
+		, "minus3" : [ "v" ]
+		, "minus4" : [ "b" ]
+		, "minus5" : [ "n" ]
+		, "minus6" : [ "m" ]
+		, "minus7" : [ "," ]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Emily Rose <emily@contactvibe.com>",
   "license": "CC0",
   "dependencies": {
+    "commander": "^2.3.0",
     "coremidi": "^0.1.1",
     "hidstream": "0.0.5"
   },

--- a/start
+++ b/start
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sudo node hid
+sudo node hid $1 $2 $3 $4


### PR DESCRIPTION
This PR adds a new mechanism for getting input from ```process.stdin```. This makes it easier to work with the cerulean if you want to use your laptop's built-in keyboard. To use this method, set ```type``` in the config.json to ```stream```. Any other values default to the HID mechanism.

I also added support for key signatures. The default is ```twelvetone```, the same as it worked before, but now you can specify others too, e.g. ```cmajor```, ```eflatminor```, etc. Signatures start with a lower case letter, a-g, an optional ```sharp``` or ```flat```, followed by ```major``` or ```minor```.

To make it easier to handle these new inputs, I added support for two command line parameters: config and key. Config specifies which config file to use, making it easier to switch between multiple config files. Key specifies the key signature.  I kinda view each config file like a separate instrument, so I decided to leave the key as separate parameter. Kinda like how a guitar is a thing, and a capo is a different thing.

The different scale types (major, minor, twelvetone) are stored as a difference array, i.e. each entry is the note difference between it and the previous entry. This makes it easy to add new scales if we want (e.g. hungarian minor).

To test out the new system, run ```./start --config ./config.stream.json --key dmajor``` and then play the following transposition of Oh Danny Boy (a dash means play nothing):

```
---- -xss
s--x sfxc
xxc- -dds
s--s xccd
x--- -faa
h--x axcd
vcc- -xss
s--s xccd
a--- ----
```

This totally raises the question: what does sheet music for the cerulean look like? :-)